### PR TITLE
Fixes typo causing console errors

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -82,10 +82,10 @@ gsap.from(headerBtn, {
           <picture>
             <source 
                 media="(min-width: 650px)"
-                srcset="./images/debbie-dann-compressed.png" />
+                srcSet="./images/debbie-dann-compressed.png" />
             <source 
                 media="(max-width: 650px)"
-                srcset="./images/debbie-dann-compressed.webp" />
+                srcSet="./images/debbie-dann-compressed.webp" />
             <img src="./images/debbie-dann-compressed.png" 
             alt="debbie dann profile" 
             className="header-img"

--- a/src/components/LinkPage.js
+++ b/src/components/LinkPage.js
@@ -37,10 +37,10 @@ const LinkPage = () => {
           <picture>
             <source 
                 media="(min-width: 650px)"
-                srcset="./images/debbie-dann-compressed.png" />
+                srcSet="./images/debbie-dann-compressed.png" />
             <source 
                 media="(max-width: 650px)"
-                srcset="./images/debbie-dann-compressed.webp" />
+                srcSet="./images/debbie-dann-compressed.webp" />
             <img src="./images/debbie-dann-compressed.png" 
             alt="debbie dann profile" 
             className="linkpage-image header-img"


### PR DESCRIPTION
`srcset` is the html attribute, but needs to be `srcSet` in jsx.