### PR TITLE
Issue/18 mobile nav close on click

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from "react";
 import { gsap, Power3 } from "gsap";
+import {HashLinkButton} from "./LinkButton";
 
 const Header = () => {
   let headerSection = useRef(null)
@@ -66,14 +67,13 @@ gsap.from(headerBtn, {
           My social media knowledge and experience of content creation help me
           to deliver beautiful websites with JavaScript, React and TailwindCSS.
         </p>
-        <button
-          ref={(el) => {
-            headerBtn = el;
-          }}
+        <HashLinkButton
+          to="#contact"
+          forwardedRef={(el) => {headerBtn = el}}
           className="header-btn"
         >
           Get in touch
-        </button>
+        </HashLinkButton>
       </section>
       <div className="sparkle-container">
           <img src="/images/sparkle.svg" className="sparkle one" alt="sparkle shape" />

--- a/src/components/LinkButton.js
+++ b/src/components/LinkButton.js
@@ -1,5 +1,5 @@
 import {useNavigate} from "react-router-dom";
-import { genericHashLink } from 'react-router-hash-link';
+import {genericHashLink} from 'react-router-hash-link';
 
 const LinkButton = (props) => {
   const {
@@ -18,11 +18,11 @@ const LinkButton = (props) => {
 
   const clickHandler = onClick ? onClick : (e) => {
     e.preventDefault();
-    navigate(to, { replace: true });
+    navigate(to, {replace: true});
   }
 
   return (
-    <button {...rest} ref={forwardedRef} onClick={clickHandler} />
+    <button {...rest} ref={forwardedRef} onClick={clickHandler}/>
   )
 }
 

--- a/src/components/LinkButton.js
+++ b/src/components/LinkButton.js
@@ -1,0 +1,30 @@
+import {useNavigate} from "react-router-dom";
+import { genericHashLink } from 'react-router-hash-link';
+
+const LinkButton = (props) => {
+  const {
+    history,
+    location,
+    match,
+    staticContext,
+    to,
+    onClick,
+    forwardedRef,
+    // ⬆ filtering out props that `button` doesn't know what to do with
+    ...rest
+  } = props
+
+  const navigate = useNavigate();
+
+  const clickHandler = onClick ? onClick : (e) => {
+    e.preventDefault();
+    navigate(to, { replace: true });
+  }
+
+  return (
+    <button {...rest} ref={forwardedRef} onClick={clickHandler} />
+  )
+}
+
+export const HashLinkButton = genericHashLink(LinkButton);
+export default LinkButton;

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -5,11 +5,17 @@ import { GiHamburgerMenu } from "react-icons/gi"
 import {MdClose} from "react-icons/md"
 import { Link } from "react-router-dom";
 import { HashLink } from 'react-router-hash-link';
-import {useState} from "react";
+import {useState, useEffect} from "react";
+import { useLocation } from "react-router-dom";
 
 const Nav = () => {
+  const pathname  = useLocation();
   const [active, setActive] = useState(false)
   const showMenu = () => setActive(!active);
+
+  useEffect(() => {
+    setActive(false);
+  }, [pathname]);
 
   return (
     <nav>


### PR DESCRIPTION
Closes #18. This PR also adds a `<HashLinkButton>` that can be used to navigate to anchors, this implements the navigation needed by the get in touch button on the homepage which should inadvertently close #23.